### PR TITLE
add test to check fiels arent downloaded again

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ which will download all the files from Weather DataHub, join them together into 
 
 You can set the environmental variable `LOG_LEVEL` to define what [log level](https://docs.python.org/3.9/library/logging.html) you would like.
 
+It may also be worth setting 'RAW_DIR' so that the raw files are saved to a certain folder,
+and not downloded again if they are already there.
+
 ## Docker
 The application can be run using docker
 

--- a/metofficedatahub/base.py
+++ b/metofficedatahub/base.py
@@ -1,8 +1,8 @@
 """ Main application for the API wrapper """
 import logging
 import os
-import fsspec
 
+import fsspec
 import requests
 from pathy import Pathy
 
@@ -17,7 +17,7 @@ class BaseMetOfficeDataHub:
 
     def __init__(
         self,
-        cache_dir: str = os.getenv('RAW_DIR', "./temp_metofficedatahub"),
+        cache_dir: str = os.getenv("RAW_DIR", "./temp_metofficedatahub"),
         client_id: str = None,
         client_secret: str = None,
     ):

--- a/metofficedatahub/base.py
+++ b/metofficedatahub/base.py
@@ -1,8 +1,10 @@
 """ Main application for the API wrapper """
 import logging
 import os
+import fsspec
 
 import requests
+from pathy import Pathy
 
 from metofficedatahub.constants import DOMAIN, ROOT
 from metofficedatahub.models import FileDetails, OrderDetails, OrderList, RunList, RunListForModel
@@ -15,7 +17,7 @@ class BaseMetOfficeDataHub:
 
     def __init__(
         self,
-        cache_dir: str = "./temp_metofficedatahub",
+        cache_dir: str = os.getenv('RAW_DIR', "./temp_metofficedatahub"),
         client_id: str = None,
         client_secret: str = None,
     ):
@@ -144,16 +146,17 @@ class BaseMetOfficeDataHub:
             filename = f"{order_id}_{file_id}.grib"
 
         filename = f"{self.cache_dir}/{filename}"
-        if not os.path.exists(filename):
+        fs = fsspec.open(Pathy(self.cache_dir).parent).fs
+        if not fs.exists(filename):
 
             data = self.call_url(
                 url=f"https://{DOMAIN}/{ROOT}/orders/{order_id}/latest/{file_id}/data",
                 headers=headers,
             )
 
-            if not os.path.isdir(self.cache_dir):
+            if not fs.isdir(self.cache_dir):
                 try:
-                    os.mkdir(self.cache_dir)
+                    fs.mkdir(self.cache_dir)
                 except Exception as e:
                     logger.error(e)
                     raise Exception(
@@ -162,10 +165,10 @@ class BaseMetOfficeDataHub:
                         f"has been made already"
                     )
 
-            with open(filename, mode="wb") as localfile:
+            with fs.open(filename, mode="wb") as localfile:
                 localfile.write(data.content)
         else:
-            logger.debug(f"{filename} already exsits so not downloading new one")
+            logger.debug(f"{filename} already exists so not downloading new one")
 
         return filename
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ h5netcdf
 scipy
 dask
 nowcasting_datamodel==0.0.36
+pathy

--- a/tests/test_multiple_files.py
+++ b/tests/test_multiple_files.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
-from unittest import mock
 from datetime import datetime
+from unittest import mock
 
 import xarray as xr
 

--- a/tests/test_multiple_files.py
+++ b/tests/test_multiple_files.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from unittest import mock
+from datetime import datetime
 
 import xarray as xr
 
@@ -29,6 +30,28 @@ def test_download_all(mock_get, metofficedatahub):
         assert len(metofficedatahub.files) > 0
         for file in metofficedatahub.files:
             assert os.path.exists(file.local_filename)
+
+
+@mock.patch("requests.get", side_effect=mocked_requests_get)
+def test_download_repeat(mock_get, metofficedatahub):
+    """Check that files are not downloaded again"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        metofficedatahub.cache_dir = tmpdirname
+        metofficedatahub.download_all_files(order_ids=["test_order_id"])
+
+        assert len(metofficedatahub.files) > 0
+        for file in metofficedatahub.files:
+            assert os.path.exists(file.local_filename)
+
+        # downloaded for second time
+        datetime_now = datetime.now()
+        metofficedatahub.download_all_files(order_ids=["test_order_id"])
+
+        # make sure the files arent downloaded again
+        for file in metofficedatahub.files:
+            assert os.path.exists(file.local_filename)
+            creation_time = os.path.getmtime(file.local_filename)
+            assert datetime.fromtimestamp(creation_time) < datetime_now
 
 
 @mock.patch("requests.get", side_effect=mocked_requests_get)


### PR DESCRIPTION
make cahce optional for s3

# Pull Request

## Description

- add cache dir as envvar
- make cahce dir possibel to be s3
- adde test

Fixes #29 

## How Has This Been Tested?

normal unittest tests
-added test

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
