### PR TITLE
Remove or ignore temporary test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ dmypy.json
 # Misc
 .DS_Store
 .idea
+
+# Default temporary directories
+/temp
+/temp_metofficedatahub

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ from metofficedatahub.multiple_files import MetOfficeDataHub
 
 
 @pytest.fixture
-def db_connection():
+def db_connection(tmp_path):
     """Database connection"""
-    url = os.getenv("DB_URL", "sqlite:///test.db")
+    url = os.getenv("DB_URL", f"sqlite:///{tmp_path}/test.db")
 
     connection = DatabaseConnection(url=url, base=Base_Forecast, echo=False)
     Base_Forecast.metadata.create_all(connection.engine)


### PR DESCRIPTION
Running the tests was creating temporary files in the repo. I could easily get rid of the `test.db` one, but I'm sure what would be the consequences to use proper temporary files for the other ones so I just added them to `.gitignore` fornow.