### PR TITLE
Run CI only on ubuntu and python 3.10

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -8,6 +8,6 @@ jobs:
   call-run-python-tests:
     uses: openclimatefix/.github/.github/workflows/python-test.yml@main
     with:
-      # pytest-cov looks at this folder
+      os_list: '["ubuntu-latest"]'
+      python-version: '["3.10"]'
       pytest_cov_dir: "metofficedatahub"
-      brew_install: "c-blosc hdf5 eccodes"


### PR DESCRIPTION
This is what we use in practice and it makes the CI faster.